### PR TITLE
AB2-415 Use Ghostery specific strings for the description in Ghost Tabs

### DIFF
--- a/l10n/de/mobile/android/base/cliqz_strings.dtd
+++ b/l10n/de/mobile/android/base/cliqz_strings.dtd
@@ -254,6 +254,8 @@
 <!ENTITY close_ghost_tabs "Ghost-Tabs schließen">
 <!ENTITY contextmenu_open_ghost_tab "In Ghost-Tab öffnen">
 <!ENTITY home_most_recent_emptyhint_ghost_tab "Psst: Durch Verwendung eines &formatS1;neuen Ghost-Tabs&formatS2; wird Ihr Verlauf nicht gespeichert.">
+<!ENTITY private_tab_panel_title2 "Ghost-Modus">
+<!ENTITY private_tab_panel_description3 "Sie browsen im Ghost-Modus: Websites, die Sie in diesem Modus besuchen, werden nicht in Ihrem Browserverlauf gespeichert, und lokale Daten einschließlich Cookies werden nicht gespeichert.">
 
 <!-- Anti-phishing -->
 <!ENTITY antiphishing_dialog_title "Warnung: betrügerische Website!">

--- a/mozilla-release/mobile/android/app/src/photon/res/layout/private_tabs_panel.xml
+++ b/mozilla-release/mobile/android/app/src/photon/res/layout/private_tabs_panel.xml
@@ -43,7 +43,8 @@
                 android:text="@string/private_tab_panel_description"
                 android:textColor="@color/photon_text_secondary"/>
 
-            <TextView
+            <!-- Cliqz Start -->
+            <!-- <TextView
                 style="@style/TextAppearance.PrivateTab.Description"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -54,8 +55,7 @@
                 android:text="@string/private_tab_panel_description2"
                 android:textColor="@color/photon_text_secondary"/>
 
-            <!-- Cliqz Start -->
-            <!-- <TextView
+            <TextView
                 style="@style/TextAppearance.PrivateTab.Description"
                 android:id="@+id/learn_more_link"
                 android:layout_width="wrap_content"

--- a/mozilla-release/mobile/android/base/locales/en-US/cliqz_strings.dtd
+++ b/mozilla-release/mobile/android/base/locales/en-US/cliqz_strings.dtd
@@ -38,7 +38,6 @@
 <!ENTITY helper_first_offline_favorite_button "Go to favorites">
 <!ENTITY helper_triple_readerview_open_message2 "Favorite Reader View items to read them offline.">
 <!ENTITY helper_triple_readerview_open_button2 "Add to favorites">
-<!ENTITY private_tab_panel_description3 "We won\'t remember any history, but downloaded files and new favorites will still be saved to your device.">
 
 <!-- Default Browser Dialog -->
 <!ENTITY default_browser_title "&brandShortName; as Default Browser">
@@ -288,6 +287,8 @@
 <!ENTITY close_ghost_tabs "Close Ghost Tabs">
 <!ENTITY contextmenu_open_ghost_tab "Open in Ghost Tab">
 <!ENTITY home_most_recent_emptyhint_ghost_tab "Psst: using a &formatS1;New Ghost Tab&formatS2; won\'t save your history.">
+<!ENTITY private_tab_panel_title2 "Ghost Mode">
+<!ENTITY private_tab_panel_description3 "You are browsing in Ghost Mode: Websites you visit in this mode will not be saved in your history, and local data, including cookies, will not be stored.">
 
 <!-- Anti-phishing -->
 <!ENTITY antiphishing_dialog_title "Warning: deceptive website!">

--- a/mozilla-release/mobile/android/base/strings.xml.in
+++ b/mozilla-release/mobile/android/base/strings.xml.in
@@ -674,10 +674,9 @@
 
   <string name="activity_stream_highlights_empty">&activity_stream_highlights_empty;</string>
 
-  <string name="private_tab_panel_title">&private_tab_panel_title;</string>
-  <string name="private_tab_panel_description">&private_tab_panel_description;</string>
   <!-- Cliqz start -->
-  <string name="private_tab_panel_description2">&private_tab_panel_description3;</string>
+  <string name="private_tab_panel_title">&private_tab_panel_title2;</string>
+  <string name="private_tab_panel_description">&private_tab_panel_description3;</string>
   <!-- Cliqz end -->
   <string name="private_tab_learn_more">&private_tab_learn_more;</string>
 


### PR DESCRIPTION
I changed the texts in the Ghost tabs

![screenshot_1535554131](https://user-images.githubusercontent.com/6861614/44796096-8b9f5600-abac-11e8-9e81-d6584c39aa6f.png)
