### PR TITLE
Update extension to 3.30.0

### DIFF
--- a/mozilla-release/config/search.txt
+++ b/mozilla-release/config/search.txt
@@ -1,2 +1,2 @@
-ghostery=http://cdn2.cliqz.com/update/edge/ghostery-android/master/1.30.0.1b79.a1e6018.zip
-cliqz=http://cdn2.cliqz.com/update/edge/cliqz-android/master/3.30.0.1b79.a1e6018.zip
+ghostery=http://cdn2.cliqz.com/update/edge/ghostery-android/v3.30/3.30.0.fcb8ed8.zip
+cliqz=http://cdn2.cliqz.com/update/edge/cliqz-android/v3.30/3.30.0.fcb8ed8.zip

--- a/mozilla-release/mobile/android/app/mobile.js
+++ b/mozilla-release/mobile/android/app/mobile.js
@@ -377,9 +377,9 @@ pref("dom.max_script_run_time", 20);
 pref("devtools.debugger.unix-domain-socket", "/data/data/@ANDROID_PACKAGE_NAME@/firefox-debugger-socket");
 
 // Cliqz start
-pref("pref.search.regional", "us")
-pref("pref.search.block.adult.content", true)
-pref("pref.search.query.suggestions", true)
+pref("pref.search.regional", "us");
+pref("pref.search.block.adult.content", true);
+pref("pref.search.query.suggestions", true);
 #ifdef MOZ_DEFAULT_USB_DEBUG
 pref("devtools.remote.usb.enabled", true);
 #else


### PR DESCRIPTION
This update includes:
- pref defaults
- https lock
- tap on card action doesn't depend on channel
- Element IDs for ci
- appName passed to extension