### PR TITLE
Update extension to 3.30.4

### DIFF
--- a/mozilla-release/config/search.txt
+++ b/mozilla-release/config/search.txt
@@ -1,2 +1,2 @@
-ghostery=https://s3.amazonaws.com/cdncliqz/update/edge/ghostery-android/v3.30/3.30.3.6b3877b.zip
-cliqz=https://s3.amazonaws.com/cdncliqz/update/edge/cliqz-android/v3.30/3.30.3.6b3877b.zip
+ghostery=http://cdn2.cliqz.com/update/edge/ghostery-android/v3.30/3.30.4.70d58d1.zip
+cliqz=http://cdn2.cliqz.com/update/edge/cliqz-android/v3.30/3.30.4.70d58d1.zip


### PR DESCRIPTION
This contains following changes:

- EX-8035: fix broken 'no results' card on landscape
- anolysis: Make use of correct storage for Android (which is isMobile but webextension platform) (#6777)
- Avoid fetch library on webextension platform (#6737)
- EX-8067: Send ready signal to android browser on request (#6770)
- EX-7947: Fix rendering the subscribe buttons
- Kill legacy telemetry for webextensions
- Revert "completely disable telemetry for web extension environment + avoid fetch for search"

cc @spacifici @khaled-cliqz 