### PR TITLE
Fix overlay panel before it's ready causing panel never to show

### DIFF
--- a/mozilla-release/mobile/android/chrome/content/browser.js
+++ b/mozilla-release/mobile/android/chrome/content/browser.js
@@ -6678,22 +6678,24 @@ var Cliqz = {
   },
 
   overlayPanel: function(panel) {
-    if (panel.hasAttribute("primary")) {
+    /* Cliqz start */
+    var currentPanel = BrowserApp.deck.selectedPanel;
+    if (currentPanel === panel && panel.hasAttribute("primary")) {
       // already visible
       return;
     }
 
-    var currentPanel = BrowserApp.deck.selectedPanel;
     if (currentPanel.hasAttribute("contentsource")) {
       // current tab is already an overlay
       // -> we simply hide it
       currentPanel.removeAttribute("primary");
-    } else {
+    } else if (currentPanel !== panel) {
       // we need to store the current active panel to be able
       // to show it when the overlay panel will close
       BrowserApp.deck.backPanel = currentPanel;
       currentPanel.removeAttribute("primary");
     }
+    /* Cliqz end */
 
     // it must be primary in order to get the touch events
     panel.setAttribute("primary", "true");


### PR DESCRIPTION
The search panel was being set to primary without getting selected,
so it was never trying to overlay it again