### PR TITLE
Disable AMO detector

### DIFF
--- a/mozilla-release/mobile/android/app/mobile.js
+++ b/mozilla-release/mobile/android/app/mobile.js
@@ -917,4 +917,6 @@ pref("general.useragent.override.google.de", "Mozilla/5.0 (Linux; Android 8.0.0;
 
 /* Cliqz start */
 pref("media.autoplay.enabled", false);
+// Prevent mozaddonmanager on AMO
+pref("privacy.resistFingerprinting.block_mozAddonManager", true); 
 /* Cliqz end */


### PR DESCRIPTION
We probably do not want the AMO integration so deep due to our integrated extensions 
![screen shot 2018-11-05 at 16 44 21](https://user-images.githubusercontent.com/5583036/48008497-1acf6980-e11a-11e8-9ebd-19830a6a6253.png)
