### PR TITLE
History fixes

### DIFF
--- a/mozilla-release/config/privacy.txt
+++ b/mozilla-release/config/privacy.txt
@@ -1,1 +1,1 @@
-https://s3.amazonaws.com/cdncliqz/update/android_browser_pre/firefox%40ghostery.com/firefox%40ghostery.com-8.2.16-android_browser-signed.xpi
+https://s3.amazonaws.com/cdncliqz/update/android_browser_pre/firefox%40ghostery.com/firefox%40ghostery.com-8.2.16.d1e4881-android_browser-signed.xpi

--- a/mozilla-release/mobile/android/base/java/org/mozilla/gecko/db/LocalBrowserDB.java
+++ b/mozilla-release/mobile/android/base/java/org/mozilla/gecko/db/LocalBrowserDB.java
@@ -2119,9 +2119,9 @@ public class LocalBrowserDB extends BrowserDB {
                     .append(" LIKE ? OR ")
                     .append(History.TITLE)
                     .append(" LIKE ?)");
-            final String escapedQuery = DatabaseUtils.sqlEscapeString(query);
-            argumentsList.add("%" + escapedQuery + "%");
-            argumentsList.add("%" + escapedQuery + "%");
+            final String escapedQuery = "%" + query + "%";
+            argumentsList.add(escapedQuery);
+            argumentsList.add(escapedQuery);
             selection = selectionBuilder.append(" COLLATE NOCASE").toString();
             final String[] conv = new String[argumentsList.size()];
             selectionArgs = argumentsList.toArray(conv);


### PR DESCRIPTION
There seems to be two problems with history:
1. mono-extension did not have `history` permission
2. changes to history sql query introduced the bug on escaping