### PR TITLE
AB2-749: change CC options string

### DIFF
--- a/mozilla-release/mobile/android/base/locales/en-US/cliqz_strings.dtd
+++ b/mozilla-release/mobile/android/base/locales/en-US/cliqz_strings.dtd
@@ -116,7 +116,7 @@
 <!ENTITY cc_restrict_site "Restrict Site">
 <!ENTITY cc_pause_ghostery "Pause Ghostery">
 <!ENTITY cc_resume_ghostery "Resume Ghostery">
-<!ENTITY cc_enhanced_options "Options">
+<!ENTITY cc_enhanced_options "More Options">
 <!ENTITY cc_enhanced_anti_tracking "Anti-Tracking">
 <!ENTITY cc_enhanced_ad_blocking "Ad Blocking">
 <!ENTITY cc_smart_blocking "Smart Blocking">


### PR DESCRIPTION
Do we support other locales? In the locales folder I found just `en-US`. Unless we generate the folder on build time.