### PR TITLE
Store react-native prefs in Gecko preferences

### DIFF
--- a/cliqz/package-lock.json
+++ b/cliqz/package-lock.json
@@ -760,9 +760,9 @@
       }
     },
     "ajv": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-      "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2014,8 +2014,8 @@
       }
     },
     "browser-core": {
-      "version": "https://s3.amazonaws.com/cdncliqz/update/edge/rn-ghostery-android/mobile-cards-android/1.35.0.26d52cd.tgz",
-      "integrity": "sha512-pLNDmwDqujN/9X/o1rBtbvFJYDi8Bav9ob8TBbSCcmXvyePHVWOZEK2d+MRyW+MpWKwZSjUulLWPdAk52wxKpg==",
+      "version": "https://s3.amazonaws.com/cdncliqz/update/edge/rn-ghostery-android/mobile-cards-android/1.35.0.c275ed8.tgz",
+      "integrity": "sha512-m3ODveRS0tQz3ObOUvLti1J9URfKEO3eiKF+tG7g2mXpAFd8zzhkXYojC+PTcLNwGs7QEP0tTKiFAkFgvTsiaQ==",
       "requires": {
         "@cliqz-oss/dexie": "^2.0.4",
         "@cliqz/adblocker": "^0.6.8",

--- a/cliqz/package.json
+++ b/cliqz/package.json
@@ -10,7 +10,7 @@
     "jsc-android": "^236355.1.1"
   },
   "dependencies": {
-    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/rn-ghostery-android/mobile-cards-android/1.35.0.26d52cd.tgz",
+    "browser-core": "https://s3.amazonaws.com/cdncliqz/update/edge/rn-ghostery-android/mobile-cards-android/1.35.0.c275ed8.tgz",
     "cliqz-logo-database": "^0.1.2",
     "moment": "^2.24.0",
     "react": "^16.6.3",

--- a/mozilla-release/mobile/android/app/mobile.js
+++ b/mozilla-release/mobile/android/app/mobile.js
@@ -372,7 +372,6 @@ pref("devtools.debugger.unix-domain-socket", "@ANDROID_PACKAGE_NAME@/firefox-deb
 
 // Cliqz start
 pref("pref.search.block.adult.content", true);
-pref("pref.search.query.suggestions", true);
 #ifdef MOZ_DEFAULT_USB_DEBUG
 pref("devtools.remote.usb.enabled", true);
 #else

--- a/mozilla-release/mobile/android/app/src/main/res/xml/preferences_general.xml
+++ b/mozilla-release/mobile/android/app/src/main/res/xml/preferences_general.xml
@@ -80,7 +80,7 @@
         <CheckBoxPreference
             android:defaultValue="true"
             android:checked="true"
-            android:key="cb_query_suggestion"
+            android:key="searchui.suggestionsEnabled"
             android:title="@string/pref_search_query_suggestions" />
 
         <CheckBoxPreference

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/BridgePackage.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/BridgePackage.java
@@ -1,32 +1,15 @@
 package com.cliqz.react;
 
-import android.content.SharedPreferences;
-
-import com.cliqz.ThemeManager;
+import com.cliqz.react.modules.BridgeModule;
+import com.cliqz.react.modules.BrowserActionsModule;
+import com.cliqz.react.modules.PrefsModule;
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.Arguments;
-import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.NativeModule;
-import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.bridge.ReactContextBaseJavaModule;
-import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.uimanager.ViewManager;
 
-import org.mozilla.gecko.EventDispatcher;
-import org.mozilla.gecko.GeckoSharedPrefs;
-import org.mozilla.gecko.PrefsHelper;
-import org.mozilla.gecko.util.BundleEventListener;
-import org.mozilla.gecko.util.EventCallback;
-import org.mozilla.gecko.util.GeckoBundle;
-import org.mozilla.gecko.util.GeckoBundleUtils;
-
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Copyright © Cliqz 2019
@@ -36,8 +19,9 @@ public class BridgePackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         final List<NativeModule> modules = new ArrayList<>();
 
-        modules.add(new Bridge(reactContext));
-        modules.add(new BrowserActions(reactContext));
+        modules.add(new BridgeModule(reactContext));
+        modules.add(new PrefsModule(reactContext));
+        modules.add(new BrowserActionsModule(reactContext));
 
         return modules;
     }
@@ -49,142 +33,5 @@ public class BridgePackage implements ReactPackage {
         viewManagers.add(new NativeDrawableManager());
 
         return viewManagers;
-    }
-
-    public class Bridge extends ReactContextBaseJavaModule implements BundleEventListener {
-        private static final String PREF_PREFIX = "searchui.";
-        private static final String SEARCHUI_PREF_NAMES = "searchui.prefNames";
-
-        private final SharedPreferences xPreferences;
-
-        private final ReactApplicationContext mReactContext;
-
-        public Bridge(ReactApplicationContext reactContext) {
-            super(reactContext);
-            mReactContext = reactContext;
-            xPreferences = GeckoSharedPrefs.forProfile(mReactContext);
-        }
-
-        @Override
-        public String getName() {
-            return "Bridge";
-        }
-
-        @Override
-        public void initialize() {
-            EventDispatcher.getInstance().registerUiThreadListener(this, "Search:Search");
-        }
-
-        @Override
-        public boolean canOverrideExistingModule() {
-            return false;
-        }
-
-        @Override
-        public void onCatalystInstanceDestroy() {
-            EventDispatcher.getInstance().unregisterUiThreadListener(this, "Search:Search");
-        }
-
-        @Override
-        public void handleMessage(String event, GeckoBundle message, EventCallback callback) {
-            switch (event) {
-                case "Search:Search":
-                    final String query = GeckoBundleUtils.safeGetString(message, "q");
-                    SearchBackground.startSearch(query);
-                    break;
-            }
-        }
-
-        @ReactMethod
-        public void replyToAction(int hash, ReadableMap response) {
-            SearchBackground.replyToAction(hash, response);
-        }
-
-        //TODO create private methods for getTheme and getCardStyle
-
-        @ReactMethod
-        public void getConfig(final Promise promise) {
-            final WritableMap outData = Arguments.createMap();
-            outData.putString("theme", ThemeManager.THEME_LIGHT);
-            outData.putString("cardStyle", "vertical");
-            promise.resolve(outData);
-        }
-
-        @ReactMethod
-        public void clearPref(String prefName) {
-            // TODO: there is no way to clear pref from JAVA - need to send message to browser.js
-            // PrefsHelper.setPref(prefName, null);
-        }
-
-        @ReactMethod
-        public void setPref(String prefName, Dynamic value) {
-            recordPrefName(prefName);
-            Object val = null;
-            switch (value.getType()) {
-                case String:
-                    val = value.asString();
-                    break;
-                case Boolean:
-                    val = value.asBoolean();
-                    break;
-                case Number:
-                    val = value.asInt();
-                    break;
-                default:
-                    return;
-            }
-            PrefsHelper.setPref(addPrefix(prefName), val);
-        }
-
-        @ReactMethod
-        public void getAllPrefs(Promise promise) {
-            WritableMap prefs = Arguments.createMap();
-            final Set<String> prefNames = getPrefNames();
-
-            PrefsHelper.getPrefs(prefNames.toArray(new String[] { }), new PrefsHelper.PrefHandler() {
-                @Override
-                public void prefValue(String pref, boolean value) {
-                    prefs.putBoolean(removePrefix(pref), value);
-                }
-
-                @Override
-                public void prefValue(String pref, int value) {
-                    prefs.putInt(removePrefix(pref), value);
-                }
-
-                @Override
-                public void prefValue(String pref, String value) {
-                    prefs.putString(removePrefix(pref), value);
-                }
-
-                @Override
-                public void finish() {
-                    promise.resolve(prefs);
-                }
-            });
-        }
-
-        private void recordPrefName(String prefName) {
-            final Set<String> prefNames = getPrefNames();
-
-            if (prefNames.add(addPrefix(prefName))) {
-                xPreferences.edit().putStringSet(SEARCHUI_PREF_NAMES, prefNames).apply();
-            }
-        }
-
-        private String removePrefix(String prefName) {
-            return prefName.substring(PREF_PREFIX.length());
-        }
-
-        private String addPrefix(String prefName) {
-            return PREF_PREFIX + prefName;
-        }
-
-        private Set<String> getPrefNames() {
-            final Set<String> prefNames = xPreferences.getStringSet(SEARCHUI_PREF_NAMES, new HashSet<>());
-            prefNames.add(addPrefix("suggestionChoice"));
-            prefNames.add(addPrefix("suggestionsEnabled"));
-            return prefNames;
-        }
     }
 }

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/BridgePackage.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/BridgePackage.java
@@ -2,6 +2,7 @@ package com.cliqz.react;
 
 import com.cliqz.react.modules.BridgeModule;
 import com.cliqz.react.modules.BrowserActionsModule;
+import com.cliqz.react.modules.LocaleConstantsModule;
 import com.cliqz.react.modules.PrefsModule;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.NativeModule;
@@ -22,6 +23,7 @@ public class BridgePackage implements ReactPackage {
         modules.add(new BridgeModule(reactContext));
         modules.add(new PrefsModule(reactContext));
         modules.add(new BrowserActionsModule(reactContext));
+        modules.add(new LocaleConstantsModule(reactContext));
 
         return modules;
     }

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/MigrationManager.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/MigrationManager.java
@@ -5,6 +5,9 @@ import com.cliqz.react.modules.PrefsModule;
 import org.mozilla.gecko.PrefsHelper;
 import org.mozilla.gecko.preferences.GeckoPreferences;
 
+/**
+ * Copyright © Cliqz 2019
+ */
 public class MigrationManager {
     private final static MigrationManager ourInstance = new MigrationManager();
 

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/MigrationManager.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/MigrationManager.java
@@ -23,7 +23,7 @@ public class MigrationManager {
                 return;
             }
             PrefsHelper.setPref(GeckoPreferences.PREFS_SEARCH_REGIONAL, "");
-            SearchBackground.getInstance().setBackendCountry(countryCode);
+            SearchBackground.setBackendCountry(countryCode);
             }
         });
     }

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/MigrationManager.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/MigrationManager.java
@@ -1,0 +1,40 @@
+package com.cliqz.react;
+
+import com.cliqz.react.modules.PrefsModule;
+
+import org.mozilla.gecko.PrefsHelper;
+import org.mozilla.gecko.preferences.GeckoPreferences;
+
+public class MigrationManager {
+    private final static MigrationManager ourInstance = new MigrationManager();
+
+    public static MigrationManager getInstance() {
+        return ourInstance;
+    }
+
+    /**
+     * Let Search handle search language
+     */
+    public void migrateBackendCountryLanguage() {
+        PrefsHelper.getPref(GeckoPreferences.PREFS_SEARCH_REGIONAL, new PrefsHelper.PrefHandlerBase() {
+            @Override
+            public void prefValue(String prefName, String countryCode) {
+            if (!(countryCode instanceof String) || countryCode.equals("")) {
+                return;
+            }
+            PrefsHelper.setPref(GeckoPreferences.PREFS_SEARCH_REGIONAL, "");
+            SearchBackground.getInstance().setBackendCountry(countryCode);
+            }
+        });
+    }
+
+    public void migrateQuerySuggestionsPref() {
+        PrefsHelper.getPref(GeckoPreferences.PREFS_SEARCH_QUERY_SUGGESTIONS, new PrefsHelper.PrefHandlerBase() {
+            @Override
+            public void prefValue(String prefName, boolean enabled) {
+                PrefsHelper.setPref(GeckoPreferences.PREFS_SEARCH_QUERY_SUGGESTIONS, "");
+                PrefsHelper.setPref(PrefsModule.PREFS_SEARCH_QUERY_SUGGESTIONS, enabled);
+            }
+        });
+    }
+}

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/SearchBackground.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/SearchBackground.java
@@ -13,8 +13,6 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.shell.MainReactPackage;
 
 import org.mozilla.gecko.BuildConfig;
-import org.mozilla.gecko.PrefsHelper;
-import org.mozilla.gecko.preferences.GeckoPreferences;
 import org.mozilla.gecko.util.EventCallback;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -49,22 +47,6 @@ public class SearchBackground implements ReactInstanceManager.ReactInstanceEvent
                 .build();
         mReactInstanceManager.addReactInstanceEventListener(this);
         mReactInstanceManager.createReactContextInBackground();
-    }
-
-    /**
-     * Let Search handle search language
-     */
-    public void migrateBackendCountryLanguage() {
-        PrefsHelper.getPref(GeckoPreferences.PREFS_SEARCH_REGIONAL, new PrefsHelper.PrefHandlerBase() {
-            @Override
-            public void prefValue(String prefName, String countryCode) {
-                if (!(countryCode instanceof String) || countryCode.equals("")) {
-                    return;
-                }
-                PrefsHelper.setPref(GeckoPreferences.PREFS_SEARCH_REGIONAL, "");
-                setBackendCountry(countryCode);
-            }
-        });
     }
 
     public void showDevOptionsDialog() {

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/BridgeModule.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/BridgeModule.java
@@ -1,5 +1,7 @@
 package com.cliqz.react.modules;
 
+import android.util.Log;
+
 import com.cliqz.ThemeManager;
 import com.cliqz.react.SearchBackground;
 import com.facebook.react.bridge.Arguments;
@@ -54,6 +56,9 @@ public class BridgeModule extends ReactContextBaseJavaModule implements BundleEv
             case "Search:Search":
                 final String query = GeckoBundleUtils.safeGetString(message, "q");
                 SearchBackground.startSearch(query);
+                break;
+            default:
+                Log.w(getClass().getSimpleName(), "Unknown event " + event);
                 break;
         }
     }

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/BridgeModule.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/BridgeModule.java
@@ -16,6 +16,9 @@ import org.mozilla.gecko.util.EventCallback;
 import org.mozilla.gecko.util.GeckoBundle;
 import org.mozilla.gecko.util.GeckoBundleUtils;
 
+/**
+ * Copyright © Cliqz 2019
+ */
 public class BridgeModule extends ReactContextBaseJavaModule implements BundleEventListener {
 
     private final ReactApplicationContext mReactContext;

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/BridgeModule.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/BridgeModule.java
@@ -1,0 +1,72 @@
+package com.cliqz.react.modules;
+
+import com.cliqz.ThemeManager;
+import com.cliqz.react.SearchBackground;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+
+import org.mozilla.gecko.EventDispatcher;
+import org.mozilla.gecko.util.BundleEventListener;
+import org.mozilla.gecko.util.EventCallback;
+import org.mozilla.gecko.util.GeckoBundle;
+import org.mozilla.gecko.util.GeckoBundleUtils;
+
+public class BridgeModule extends ReactContextBaseJavaModule implements BundleEventListener {
+
+    private final ReactApplicationContext mReactContext;
+
+    public BridgeModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        mReactContext = reactContext;
+    }
+
+    @Override
+    public String getName() {
+        return "Bridge";
+    }
+
+    @Override
+    public void initialize() {
+        EventDispatcher.getInstance().registerUiThreadListener(this, "Search:Search");
+    }
+
+    @Override
+    public boolean canOverrideExistingModule() {
+        return false;
+    }
+
+    @Override
+    public void onCatalystInstanceDestroy() {
+        EventDispatcher.getInstance().unregisterUiThreadListener(this, "Search:Search");
+    }
+
+    @Override
+    public void handleMessage(String event, GeckoBundle message, EventCallback callback) {
+        switch (event) {
+            case "Search:Search":
+                final String query = GeckoBundleUtils.safeGetString(message, "q");
+                SearchBackground.startSearch(query);
+                break;
+        }
+    }
+
+    @ReactMethod
+    public void replyToAction(int hash, ReadableMap response) {
+        SearchBackground.replyToAction(hash, response);
+    }
+
+    //TODO create private methods for getTheme and getCardStyle
+
+    @ReactMethod
+    public void getConfig(final Promise promise) {
+        final WritableMap outData = Arguments.createMap();
+        outData.putString("theme", ThemeManager.THEME_LIGHT);
+        outData.putString("cardStyle", "vertical");
+        promise.resolve(outData);
+    }
+}

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/BrowserActionsModule.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/BrowserActionsModule.java
@@ -1,4 +1,4 @@
-package com.cliqz.react;
+package com.cliqz.react.modules;
 
 import android.content.Context;
 import android.database.Cursor;
@@ -22,11 +22,11 @@ import org.mozilla.gecko.util.GeckoBundle;
 /**
  * Copyright © Cliqz 2019
  */
-public class BrowserActions extends ReactContextBaseJavaModule {
+public class BrowserActionsModule extends ReactContextBaseJavaModule {
 
     final private ReactContext mReactContext;
 
-    public BrowserActions(ReactApplicationContext reactContext) {
+    public BrowserActionsModule(ReactApplicationContext reactContext) {
         super(reactContext);
         mReactContext = reactContext;
     }

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/LocaleConstantsModule.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/LocaleConstantsModule.java
@@ -1,0 +1,30 @@
+package com.cliqz.react.modules;
+
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Copyright © Cliqz 2019
+ */
+public class LocaleConstantsModule extends ReactContextBaseJavaModule {
+
+    public LocaleConstantsModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "LocaleConstantsModule";
+    }
+
+    @Override
+    public Map<String, Object> getConstants() {
+        Map<String, Object> ua = new HashMap<>();
+        ua.put("lang", Locale.getDefault().getLanguage());
+        return ua;
+    }
+}

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/PrefsModule.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/PrefsModule.java
@@ -24,6 +24,7 @@ import java.util.Set;
 public class PrefsModule extends ReactContextBaseJavaModule {
     private static final String PREF_PREFIX = "searchui.";
     private static final String SEARCHUI_PREF_NAMES = "searchui.prefNames";
+    public static String PREFS_SEARCH_QUERY_SUGGESTIONS = PREF_PREFIX + "suggestionsEnabled";
     private final SharedPreferences mPreferences;
     private final ArrayList<Callback> mCallbacks = new ArrayList<>();
     private final PrefsHelper.PrefHandler mPrefHandler = new PrefsHelper.PrefHandler() {
@@ -140,7 +141,7 @@ public class PrefsModule extends ReactContextBaseJavaModule {
     private Set<String> getPrefNames() {
         final Set<String> prefNames = mPreferences.getStringSet(SEARCHUI_PREF_NAMES, new HashSet<>());
         prefNames.add(addPrefix("suggestionChoice"));
-        prefNames.add(addPrefix("suggestionsEnabled"));
+        prefNames.add(PREFS_SEARCH_QUERY_SUGGESTIONS);
         return prefNames;
     }
 

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/PrefsModule.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/PrefsModule.java
@@ -1,0 +1,116 @@
+package com.cliqz.react.modules;
+
+import android.content.SharedPreferences;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Dynamic;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.WritableMap;
+
+import org.mozilla.gecko.GeckoSharedPrefs;
+import org.mozilla.gecko.PrefsHelper;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class PrefsModule extends ReactContextBaseJavaModule {
+    private static final String PREF_PREFIX = "searchui.";
+    private static final String SEARCHUI_PREF_NAMES = "searchui.prefNames";
+
+    private final SharedPreferences mPreferences;
+
+    public PrefsModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        mPreferences = GeckoSharedPrefs.forProfile(reactContext);
+    }
+
+    @Override
+    public String getName() {
+        return "Prefs";
+    }
+
+    @Override
+    public boolean canOverrideExistingModule() {
+        return false;
+    }
+
+    @ReactMethod
+    public void clearPref(String prefName) {
+        // TODO: there is no way to clear pref from JAVA - need to send message to browser.js
+        // PrefsHelper.setPref(prefName, null);
+    }
+
+    @ReactMethod
+    public void setPref(String prefName, Dynamic value) {
+        recordPrefName(prefName);
+        Object val = null;
+        switch (value.getType()) {
+            case String:
+                val = value.asString();
+                break;
+            case Boolean:
+                val = value.asBoolean();
+                break;
+            case Number:
+                val = value.asInt();
+                break;
+            default:
+                return;
+        }
+        PrefsHelper.setPref(addPrefix(prefName), val);
+    }
+
+    @ReactMethod
+    public void getAllPrefs(Promise promise) {
+        WritableMap prefs = Arguments.createMap();
+        final Set<String> prefNames = getPrefNames();
+
+        PrefsHelper.getPrefs(prefNames.toArray(new String[] { }), new PrefsHelper.PrefHandler() {
+            @Override
+            public void prefValue(String pref, boolean value) {
+                prefs.putBoolean(removePrefix(pref), value);
+            }
+
+            @Override
+            public void prefValue(String pref, int value) {
+                prefs.putInt(removePrefix(pref), value);
+            }
+
+            @Override
+            public void prefValue(String pref, String value) {
+                prefs.putString(removePrefix(pref), value);
+            }
+
+            @Override
+            public void finish() {
+                promise.resolve(prefs);
+            }
+        });
+    }
+
+    private void recordPrefName(String prefName) {
+        final Set<String> prefNames = getPrefNames();
+
+        if (prefNames.add(addPrefix(prefName))) {
+            mPreferences.edit().putStringSet(SEARCHUI_PREF_NAMES, prefNames).apply();
+        }
+    }
+
+    private String removePrefix(String prefName) {
+        return prefName.substring(PREF_PREFIX.length());
+    }
+
+    private String addPrefix(String prefName) {
+        return PREF_PREFIX + prefName;
+    }
+
+    private Set<String> getPrefNames() {
+        final Set<String> prefNames = mPreferences.getStringSet(SEARCHUI_PREF_NAMES, new HashSet<>());
+        prefNames.add(addPrefix("suggestionChoice"));
+        prefNames.add(addPrefix("suggestionsEnabled"));
+        return prefNames;
+    }
+}

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/PrefsModule.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/PrefsModule.java
@@ -97,7 +97,7 @@ public class PrefsModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void getAllPrefs(Promise promise) {
-        WritableMap prefs = Arguments.createMap();
+        final WritableMap prefs = Arguments.createMap();
         PrefsHelper.getPrefs(getPrefNamesArray(), new PrefsHelper.PrefHandler() {
             @Override
             public void prefValue(String pref, boolean value) {
@@ -150,7 +150,9 @@ public class PrefsModule extends ReactContextBaseJavaModule {
     }
 
     private String[] getPrefNamesArray() {
-        return getPrefNames().toArray(new String[] { });
+        final Set<String> namesSet = getPrefNames();
+        final String[] names = new String[namesSet.size()];
+        return namesSet.toArray(names);
     }
 
     private void startPrefsListener() {

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/SearchEnginesModule.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/SearchEnginesModule.java
@@ -1,4 +1,4 @@
-package com.cliqz.react;
+package com.cliqz.react.modules;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Promise;
@@ -17,7 +17,7 @@ public class SearchEnginesModule extends ReactContextBaseJavaModule {
 
     @Override
     public String getName() {
-        return "SearchEnginesModule";
+        return "SearchEngines";
     }
 
     @ReactMethod

--- a/mozilla-release/mobile/android/base/java/org/mozilla/gecko/GeckoApp.java
+++ b/mozilla-release/mobile/android/base/java/org/mozilla/gecko/GeckoApp.java
@@ -91,6 +91,7 @@ import android.widget.SimpleAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.cliqz.react.MigrationManager;
 import com.cliqz.react.SearchBackground;
 
 import org.json.JSONArray;
@@ -1789,7 +1790,9 @@ public abstract class GeckoApp extends GeckoActivity
                 }
             }
             if (prefsVersionCode <= GHOSTERY_VERSION_2_3) {
-                SearchBackground.getInstance().migrateBackendCountryLanguage();
+                final MigrationManager migrationManager = MigrationManager.getInstance();
+                migrationManager.migrateBackendCountryLanguage();
+                migrationManager.migrateQuerySuggestionsPref();
             }
         }
         /* Cliqz End */

--- a/mozilla-release/mobile/android/base/java/org/mozilla/gecko/preferences/GeckoPreferences.java
+++ b/mozilla-release/mobile/android/base/java/org/mozilla/gecko/preferences/GeckoPreferences.java
@@ -62,6 +62,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import com.cliqz.react.SearchBackground;
+import com.cliqz.react.modules.PrefsModule;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 
@@ -166,6 +167,7 @@ public class GeckoPreferences
     // public static final String PREFS_VOICE_INPUT_ENABLED = NON_PREF_PREFIX + "voice_input_enabled";
     public static final String PREFS_QRCODE_ENABLED = NON_PREF_PREFIX + "qrcode_enabled";
     public static final String PREFS_AUTO_COMPLETE = "pref.search.auto.completion";
+    public static final String PREFS_SEARCH_ADULT_RESULTS = "pref.search.block.adult.content";
     public static final String PREFS_OFFRZ_LAST_SIGNATURE = NON_PREF_PREFIX + "offrz.last.signature";
     private static final String PREFS_CLEAR_PRIVATE_DATA = NON_PREF_PREFIX + "privacy.clear";
 
@@ -1419,6 +1421,11 @@ public class GeckoPreferences
 
 
         /* Cliqz Start */
+        if (PREFS_SEARCH_ADULT_RESULTS.equals((prefName))) {
+            PrefsHelper.setPref(PrefsModule.PREFS_SEARCH_ADULT_RESULTS, (boolean) newValue ? "conservative" : "liberal");
+            PrefsHelper.setPref(PREFS_SEARCH_ADULT_RESULTS, newValue);
+            return true;
+        }
         if (PREFS_TELEMETRY_ENABLED.equals(prefName)) {
             PrefsHelper.setPref(PREFS_TELEMETRY_ENABLED, (Boolean) newValue);
             return true;

--- a/mozilla-release/mobile/android/base/java/org/mozilla/gecko/preferences/PreferenceManager.java
+++ b/mozilla-release/mobile/android/base/java/org/mozilla/gecko/preferences/PreferenceManager.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 
+import com.cliqz.react.modules.PrefsModule;
+
 import org.mozilla.gecko.GeckoSharedPrefs;
 import org.mozilla.gecko.PrefsHelper;
 
@@ -94,7 +96,7 @@ public class PreferenceManager {
     }
 
     public boolean isQuerySuggestionsEnabled(){
-        return mAppSharedPreferences.getBoolean(GeckoPreferences.PREFS_SEARCH_QUERY_SUGGESTIONS,
+        return mAppSharedPreferences.getBoolean(PrefsModule.PREFS_SEARCH_QUERY_SUGGESTIONS,
                 true);
     }
 

--- a/mozilla-release/mobile/android/chrome/content/browser.js
+++ b/mozilla-release/mobile/android/chrome/content/browser.js
@@ -6526,27 +6526,6 @@ GlobalEventDispatcher.registerListener(this, [
 
     Services.cpmm.addMessageListener("MessageChannel:Messages",
       this._extensionListener.bind(this));
-
-    Services.prefs.addObserver('pref.search.regional', () => {
-      const value = Services.prefs.getCharPref('pref.search.regional');
-      this.messageExtension({
-        module: "search",
-        action: "setBackendCountry",
-        args: [value]
-      });
-    });
-
-    Services.prefs.addObserver("pref.search.block.adult.content", () => {
-      const value = Services.prefs.getBoolPref("pref.search.block.adult.content");
-      const key = value ? "conservative" : "liberal";
-      this.messageExtension({
-        module: "search",
-        action: "setAdultFilter",
-        args: [key]
-      });
-    });
-
-    this._syncSearchPrefs();
   },
 
   READY_STATUS: {
@@ -6821,19 +6800,6 @@ GlobalEventDispatcher.registerListener(this, [
     delete BrowserApp.deck.backPanel;
 
     return true;
-  },
-
-  _syncSearchPrefs() {
-    const messages = [];
-    messages.push(["setAdultFilter", Services.prefs.getBoolPref("pref.search.block.adult.content") ? "conservative" : "liberal" ]);
-
-    messages.forEach((msg) => {
-      this.messageExtension({
-        module: "search",
-        action: msg[0],
-        args: [ msg[1] ]
-      });
-    });
   },
 
   onEvent: function(event, data, callbacks) {

--- a/mozilla-release/mobile/android/chrome/content/browser.js
+++ b/mozilla-release/mobile/android/chrome/content/browser.js
@@ -6546,15 +6546,6 @@ GlobalEventDispatcher.registerListener(this, [
       });
     });
 
-    Services.prefs.addObserver("pref.search.query.suggestions", () => {
-      const value = Services.prefs.getBoolPref("pref.search.query.suggestions");
-      this.messageExtension({
-        module: "search",
-        action: "setQuerySuggestions",
-        args: [value]
-      });
-    });
-
     this._syncSearchPrefs();
   },
 
@@ -6835,7 +6826,6 @@ GlobalEventDispatcher.registerListener(this, [
   _syncSearchPrefs() {
     const messages = [];
     messages.push(["setAdultFilter", Services.prefs.getBoolPref("pref.search.block.adult.content") ? "conservative" : "liberal" ]);
-    messages.push(["setQuerySuggestions", Services.prefs.getBoolPref("pref.search.query.suggestions")]);
 
     messages.forEach((msg) => {
       this.messageExtension({


### PR DESCRIPTION
Required for:
https://cliqztix.atlassian.net/browse/AB2-844

Implements:
https://cliqztix.atlassian.net/browse/AB2-852
https://cliqztix.atlassian.net/browse/AB2-853

Also:
* migrating old prefs to new ones
* cleaning bits of browser.js
* reorganizing code around react-native modules

Important: please squash on merge


Works in pair with: https://github.com/cliqz/navigation-extension/pull/7653