### PR TITLE
searchui: rename LocaleConstants module

### DIFF
--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/LocaleConstantsModule.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/modules/LocaleConstantsModule.java
@@ -18,7 +18,7 @@ public class LocaleConstantsModule extends ReactContextBaseJavaModule {
 
     @Override
     public String getName() {
-        return "LocaleConstantsModule";
+        return "LocaleConstants";
     }
 
     @Override


### PR DESCRIPTION
The name expected from react-native was different than the one we expose.