### PR TITLE
React native: reuse react view

### DIFF
--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/SearchBackground.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/SearchBackground.java
@@ -4,12 +4,12 @@ import android.app.Application;
 import android.util.SparseArray;
 
 import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
-import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
@@ -19,6 +19,7 @@ import org.mozilla.gecko.BuildConfig;
 import org.mozilla.gecko.util.EventCallback;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import android.content.Context;
 
 /**
  * Copyright © Cliqz 2019
@@ -27,6 +28,7 @@ public class SearchBackground implements ReactInstanceManager.ReactInstanceEvent
     private static SearchBackground ourInstance;
     public final ReactInstanceManager mReactInstanceManager;
     private ReactContext mReactContext;
+    public ReactRootView mReactRootView;
     private final SparseArray<EventCallback> callbacks = new SparseArray<>();
     AtomicInteger idGenerator = new AtomicInteger(1);
 
@@ -46,10 +48,9 @@ public class SearchBackground implements ReactInstanceManager.ReactInstanceEvent
                 .addPackage(new BridgePackage())
                 .addPackage(new MainReactPackage())
                 .setUseDeveloperSupport(BuildConfig.DEBUG)
-                .setInitialLifecycleState(LifecycleState.BEFORE_RESUME)
+                .setInitialLifecycleState(LifecycleState.BEFORE_CREATE)
                 .build();
         mReactInstanceManager.addReactInstanceEventListener(this);
-        mReactInstanceManager.createReactContextInBackground();
     }
 
     public void showDevOptionsDialog() {
@@ -183,6 +184,17 @@ public class SearchBackground implements ReactInstanceManager.ReactInstanceEvent
     @Override
     public void onReactContextInitialized(ReactContext context) {
         mReactContext = context;
+        createView(context);
+    }
+
+    /**
+     * View can be forced
+     */
+    public void createView(Context context) {
+        if (mReactRootView == null) {
+            mReactRootView = new ReactRootView(context);
+            mReactRootView.startReactApplication(mReactInstanceManager, "BrowserCoreApp", null);
+        }
     }
 
     private static ReadableMap getSearchSenderArgument() {

--- a/mozilla-release/mobile/android/base/java/com/cliqz/react/SearchUI.java
+++ b/mozilla-release/mobile/android/base/java/com/cliqz/react/SearchUI.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
 
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactRootView;
@@ -30,10 +31,10 @@ public class SearchUI {
         mBackgroundManager = AppBackgroundManager.getInstance(context);
 
         final SearchBackground mSearchBackground = SearchBackground.getInstance();
-        mReactInstanceManager = mSearchBackground.mReactInstanceManager;
+        mSearchBackground.createView(context);
 
-        mReactRootView = new ReactRootView(context);
-        mReactRootView.startReactApplication(mReactInstanceManager, "BrowserCoreApp", null);
+        mReactInstanceManager = mSearchBackground.mReactInstanceManager;
+        mReactRootView = mSearchBackground.mReactRootView;
     }
 
     public void show() {
@@ -71,7 +72,6 @@ public class SearchUI {
 
     public void onDestroy() {
         if (mReactRootView != null) {
-            mReactRootView.unmountReactApplication();
             mReactRootView = null;
         }
     }


### PR DESCRIPTION
With this approach the react application gets started as soon as react context gets initialized (or resumed), or as soon as activity is requesting react view.

React View will never be unmounted or destroyed and will be kept in memory to provide access to search preferences inside the settings activity.